### PR TITLE
(ADD) - Units now have a turn order

### DIFF
--- a/Assets/Scripts/BattleManager.cs
+++ b/Assets/Scripts/BattleManager.cs
@@ -19,9 +19,15 @@ public class BattleManager : MonoBehaviour {
     Unit activeUnit;
 	int unitIndex = 0;
 
+    //Turn Order
+    [SerializeField] List<Unit> roundTurnOrder;
+    [SerializeField] int turnIndex;
+    [SerializeField] int roundNumber = 0;
+
     //AI Commands
     List<Command> commands;
     int commandIndex = 0;
+    bool unitSlowed;
 
     //Events this turn
     bool unitMoved;
@@ -51,9 +57,16 @@ public class BattleManager : MonoBehaviour {
 	void Start () {
         //GenerateUnits();
         AddUnitsFromMap();
-        activeUnit = units[unitIndex];
+        NextRound();
+        activeUnit = roundTurnOrder[turnIndex];
         ProcessTurn();
 	}
+
+    // Update is called once per frame
+    void Update()
+    {
+
+    }
 
     private void AddUnitsFromMap()
     {
@@ -62,10 +75,18 @@ public class BattleManager : MonoBehaviour {
             units.Add(u);
     }
 
-    // Update is called once per frame
-    void Update () {
+    private void NextRound()
+    {
+        //TODO add other things assiciated with ending a round
+        turnIndex = 0;
+        roundNumber++;
+        unitSlowed = false;
+        roundTurnOrder = new List<Unit>(units); //TODO Maybe make this the previous turnOrder as seed
+        UpdateTurnOrder(turnIndex); //Update the turn order for all units
+        DisplayTurnOrder();
+    }
 
-	}
+
 
     public void NextTurn()
     {
@@ -94,13 +115,39 @@ public class BattleManager : MonoBehaviour {
         map.ResetTileColors();
     }
 
+    //Updates the turn order for all units starting at the index given
+    //This allows for this function be used after a unt is slowed to imediatily 
+    //Update and display the turn order and for the turn order to be updated each round
+    private void UpdateTurnOrder(int index)
+    {
+        //Get units to update
+        List<Unit> turnsToUpdate = new List<Unit>();
+        for(int i = index; i < roundTurnOrder.Count; i++)
+        {
+            turnsToUpdate.Add(roundTurnOrder[i]);
+        }
+        //TODO Convert this to a GetSpeed and Reverse the sort
+        turnsToUpdate.Sort((a, b) => a.GetMass().CompareTo(b.GetMass()));
+        //Replace updated units
+        for(int i = index; i < roundTurnOrder.Count; i++)
+        {
+            roundTurnOrder[i] = turnsToUpdate[i - index];
+        }
+    }
+
     private void UpdateActiveUnit()
     {
-        if (unitIndex + 1 < units.Count)
-            unitIndex++;
+        //if (unitIndex + 1 < units.Count)
+        //    unitIndex++;
+        //else
+        //    unitIndex = 0;
+        //activeUnit = units[unitIndex];
+        if (turnIndex + 1 < roundTurnOrder.Count)
+            turnIndex++;
         else
-            unitIndex = 0;
-        activeUnit = units[unitIndex];
+            NextRound();
+        activeUnit = roundTurnOrder[turnIndex];
+
     }
 
     public void ProcessTurn()
@@ -215,6 +262,12 @@ public class BattleManager : MonoBehaviour {
         {
             u.CurrentTile.SetTileColor(Tile.TileColor.ally);
         }
+
+    }
+
+    //TODO Implement this
+    private void DisplayTurnOrder()
+    {
 
     }
 


### PR DESCRIPTION
 Currently it is updated each round and rounds are kept track of. Turn order can be easily updated at any time. Currently turn order is based on mass to be changed to speed.